### PR TITLE
Remove "?>" at the end of PHP files

### DIFF
--- a/MundiPaggService/Converters/DebitConverter.php
+++ b/MundiPaggService/Converters/DebitConverter.php
@@ -468,4 +468,3 @@ class DebitConverter implements IDebitConverter {
 		return $onlineDebitTransactionData;
 	}
 }
-?>

--- a/MundiPaggService/Converters/IDebitConverter.php
+++ b/MundiPaggService/Converters/IDebitConverter.php
@@ -38,4 +38,3 @@ interface IDebitConverter {
 	public function ConvertToOnlineDebitTransactionDataCollection(array $responseArray);
 	public function ConvertToOnlineDebitTransactionData($response);
 }
-?>

--- a/MundiPaggService/Converters/IRestConverter.php
+++ b/MundiPaggService/Converters/IRestConverter.php
@@ -53,4 +53,3 @@ interface IRestConverter {
 	public function ConvertBoletoTransactionDataCollectionFromResponse($boletoTransactionDataCollection);
 	public function ConvertCreditCardDataCollectionFromResponse($creditCardDataCollection);
 }
-?>

--- a/MundiPaggService/Converters/ISoapConverter.php
+++ b/MundiPaggService/Converters/ISoapConverter.php
@@ -53,4 +53,3 @@ interface ISoapConverter {
 	public function ConvertBoletoTransactionDataCollectionFromResponse($boletoTransactionDataCollection);
 	public function ConvertCreditCardDataCollectionFromResponse($creditCardDataCollection);
 }
-?>

--- a/MundiPaggService/Converters/RestConverter.php
+++ b/MundiPaggService/Converters/RestConverter.php
@@ -638,4 +638,3 @@ class RestConverter implements IRestConverter {
 		return $newCreditCardDataCollection;
 	}
 }
-?>

--- a/MundiPaggService/Converters/SoapConverter.php
+++ b/MundiPaggService/Converters/SoapConverter.php
@@ -755,4 +755,3 @@ class SoapConverter implements ISoapConverter {
 		return $newccData;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/BoletoTransaction.php
+++ b/MundiPaggService/DataContracts/BoletoTransaction.php
@@ -39,4 +39,3 @@ class BoletoTransaction {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/BoletoTransactionData.php
+++ b/MundiPaggService/DataContracts/BoletoTransactionData.php
@@ -63,4 +63,3 @@ class BoletoTransactionData {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/BoletoTransactionResult.php
+++ b/MundiPaggService/DataContracts/BoletoTransactionResult.php
@@ -22,4 +22,3 @@ class BoletoTransactionResult {
 	/*@var [string] The Transaction Reference*/
 	public $TransactionReference; 
 }
-?>

--- a/MundiPaggService/DataContracts/Buyer.php
+++ b/MundiPaggService/DataContracts/Buyer.php
@@ -87,4 +87,3 @@ class Buyer {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/BuyerAddress.php
+++ b/MundiPaggService/DataContracts/BuyerAddress.php
@@ -35,4 +35,3 @@ class BuyerAddress {
 		$this->ZipCode = "";
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreateOrderRequest.php
+++ b/MundiPaggService/DataContracts/CreateOrderRequest.php
@@ -78,4 +78,3 @@ class CreateOrderRequest {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreateOrderResponse.php
+++ b/MundiPaggService/DataContracts/CreateOrderResponse.php
@@ -80,4 +80,3 @@ class CreateOrderResponse {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreditCardData.php
+++ b/MundiPaggService/DataContracts/CreditCardData.php
@@ -31,4 +31,3 @@ class CreditCardData {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreditCardTransaction.php
+++ b/MundiPaggService/DataContracts/CreditCardTransaction.php
@@ -76,4 +76,3 @@ class CreditCardTransaction {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreditCardTransactionData.php
+++ b/MundiPaggService/DataContracts/CreditCardTransactionData.php
@@ -95,4 +95,3 @@ class CreditCardTransactionData {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/CreditCardTransactionResult.php
+++ b/MundiPaggService/DataContracts/CreditCardTransactionResult.php
@@ -80,4 +80,3 @@ class CreditCardTransactionResult {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/BuyerAddressRequest.php
+++ b/MundiPaggService/DataContracts/Debit/BuyerAddressRequest.php
@@ -41,4 +41,3 @@ class BuyerAddressRequest {
         $this->AddressTypeEnum = AddressTypeEnum::__default;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/BuyerRequest.php
+++ b/MundiPaggService/DataContracts/Debit/BuyerRequest.php
@@ -57,4 +57,3 @@ class BuyerRequest {
         $this->BuyerAddressCollection = null;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/Enum.php
+++ b/MundiPaggService/DataContracts/Debit/Enum.php
@@ -85,4 +85,3 @@
         const Error = 'Error';
         const Warning = 'Warning';
     }
-?>

--- a/MundiPaggService/DataContracts/Debit/ErrorItem.php
+++ b/MundiPaggService/DataContracts/Debit/ErrorItem.php
@@ -22,4 +22,3 @@ class ErrorItem {
 	}
 }
 
-?>

--- a/MundiPaggService/DataContracts/Debit/ErrorReport.php
+++ b/MundiPaggService/DataContracts/Debit/ErrorReport.php
@@ -13,4 +13,3 @@ class ErrorReport {
 		$this->ErrorItemCollection = null;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/OnlineDebitRequest.php
+++ b/MundiPaggService/DataContracts/Debit/OnlineDebitRequest.php
@@ -51,4 +51,3 @@ class OnlineDebitRequest {
     	$this->OrderRequest = null;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/OnlineDebitResult.php
+++ b/MundiPaggService/DataContracts/Debit/OnlineDebitResult.php
@@ -53,4 +53,3 @@ class OnlineDebitResult {
         $this->TransactionKeyToBank = null;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/OnlineDebitTransactionData.php
+++ b/MundiPaggService/DataContracts/Debit/OnlineDebitTransactionData.php
@@ -36,4 +36,3 @@ class OnlineDebitTransactionData {
 			$this->BankPaymentDate = null;
 		}
     }
-?>

--- a/MundiPaggService/DataContracts/Debit/OrderData.php
+++ b/MundiPaggService/DataContracts/Debit/OrderData.php
@@ -44,4 +44,3 @@ class OrderData {
         $this->MerchantKey = null;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/OrderRequest.php
+++ b/MundiPaggService/DataContracts/Debit/OrderRequest.php
@@ -13,4 +13,3 @@ class OrderRequest {
     	$this->AmountInCents = 0;
     }
 }
-?>

--- a/MundiPaggService/DataContracts/Debit/PhoneRequest.php
+++ b/MundiPaggService/DataContracts/Debit/PhoneRequest.php
@@ -25,4 +25,3 @@ class PhoneRequest {
         $this->PhoneTypeEnum = PhoneTypeEnum::__default;
     }
 }
-?> 

--- a/MundiPaggService/DataContracts/Debit/QueryOrderResponse.php
+++ b/MundiPaggService/DataContracts/Debit/QueryOrderResponse.php
@@ -24,4 +24,3 @@ class QueryOrderResponse {
 		$this->ErrorReport = null;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/Enum.php
+++ b/MundiPaggService/DataContracts/Enum.php
@@ -180,4 +180,3 @@
 		const Voided = 'Voided'; //6,
 		const WithError = 'WithError'; //99,
 	}
-?>

--- a/MundiPaggService/DataContracts/ErrorItem.php
+++ b/MundiPaggService/DataContracts/ErrorItem.php
@@ -12,4 +12,3 @@ class ErrorItem {
 	/*@var [SeverityCodeEnum] Severity code */
 	public $SeverityCodeEnum;
 }
-?>

--- a/MundiPaggService/DataContracts/ErrorReport.php
+++ b/MundiPaggService/DataContracts/ErrorReport.php
@@ -8,4 +8,3 @@ class ErrorReport {
 	/*@var [ErrorItem] Error Item*/
 	public $ErrorItemCollection; 
 }
-?>

--- a/MundiPaggService/DataContracts/GetInstantBuyDataRequest.php
+++ b/MundiPaggService/DataContracts/GetInstantBuyDataRequest.php
@@ -29,4 +29,3 @@ class GetInstantBuyDataRequest {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/GetInstantBuyDataResponse.php
+++ b/MundiPaggService/DataContracts/GetInstantBuyDataResponse.php
@@ -49,4 +49,3 @@ class GetInstantBuyDataResponse {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/ManageCreditCardTransactionRequest.php
+++ b/MundiPaggService/DataContracts/ManageCreditCardTransactionRequest.php
@@ -13,4 +13,3 @@ class ManageCreditCardTransactionRequest {
 		$this->TransactionReference = "";
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/ManageOrderRequest.php
+++ b/MundiPaggService/DataContracts/ManageOrderRequest.php
@@ -25,4 +25,3 @@ class ManageOrderRequest {
 		$this->RequestKey = null;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/ManageOrderResponse.php
+++ b/MundiPaggService/DataContracts/ManageOrderResponse.php
@@ -54,4 +54,3 @@ class ManageOrderResponse {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/MundiPaggSuggestion.php
+++ b/MundiPaggService/DataContracts/MundiPaggSuggestion.php
@@ -6,4 +6,3 @@ class MundiPaggSuggestion {
 	public $Code; // int
 	public $Message; // string
 }
-?>

--- a/MundiPaggService/DataContracts/OrderData.php
+++ b/MundiPaggService/DataContracts/OrderData.php
@@ -52,4 +52,3 @@ class OrderData {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/QueryOrderRequest.php
+++ b/MundiPaggService/DataContracts/QueryOrderRequest.php
@@ -29,4 +29,3 @@ class QueryOrderRequest {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/QueryOrderResponse.php
+++ b/MundiPaggService/DataContracts/QueryOrderResponse.php
@@ -49,4 +49,3 @@ class QueryOrderResponse {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/Recurrency.php
+++ b/MundiPaggService/DataContracts/Recurrency.php
@@ -21,4 +21,3 @@ class Recurrency {
 		$this->Recurrences = null;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/RetryOrderCreditCardTransactionRequest.php
+++ b/MundiPaggService/DataContracts/RetryOrderCreditCardTransactionRequest.php
@@ -21,4 +21,3 @@ class RetryOrderCreditCardTransactionRequest {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/RetryOrderRequest.php
+++ b/MundiPaggService/DataContracts/RetryOrderRequest.php
@@ -41,4 +41,3 @@ class RetryOrderRequest {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/RetryOrderResponse.php
+++ b/MundiPaggService/DataContracts/RetryOrderResponse.php
@@ -61,4 +61,3 @@ class RetryOrderResponse {
 		return $str;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/ShoppingCart.php
+++ b/MundiPaggService/DataContracts/ShoppingCart.php
@@ -13,4 +13,3 @@ class ShoppingCart {
 		$this->ShoppingCartCollection = null;
 	}
 }
-?>

--- a/MundiPaggService/DataContracts/ShoppingCartItem.php
+++ b/MundiPaggService/DataContracts/ShoppingCartItem.php
@@ -23,4 +23,3 @@ class ShoppingCartItem {
 		$this->UnitCostInCents = 0;
 	}
 }
-?>

--- a/MundiPaggService/Helpers/BasicHttpClient.php
+++ b/MundiPaggService/Helpers/BasicHttpClient.php
@@ -170,4 +170,3 @@ class BasicHttpClient implements IHttpClient {
 		}
 	}
 }
-?>

--- a/MundiPaggService/Helpers/HttpResponse.php
+++ b/MundiPaggService/Helpers/HttpResponse.php
@@ -11,4 +11,3 @@ class HttpResponse {
 
 	public $TotalTimeInSeconds;
 }
-?>

--- a/MundiPaggService/Helpers/IHttpClient.php
+++ b/MundiPaggService/Helpers/IHttpClient.php
@@ -14,4 +14,3 @@ interface IHttpClient {
 	public function GetData($uri = null, $operationTimeout = null, $httpHeader = null, $isBinaryResponse = false);
 	public function PostData($postData, $uri = null, $operationTimeout = null, $httpHeader = null, $isBinaryResponse = false);
 }
-?>

--- a/MundiPaggService/PostNotification/BoletoTransactionNotification.php
+++ b/MundiPaggService/PostNotification/BoletoTransactionNotification.php
@@ -19,4 +19,3 @@ class BoletoTransactionNotification {
 	/*@var [string] Boleto Transaction Status */
 	public $BoletoTransactionStatus;
 }
-?>

--- a/MundiPaggService/PostNotification/CreditCardTransactionNotification.php
+++ b/MundiPaggService/PostNotification/CreditCardTransactionNotification.php
@@ -29,4 +29,3 @@ class CreditCardTransactionNotification {
 	/*@var [string] CreditCard Transaction Status */
 	public $CreditCardTransactionStatus;
 }
-?>

--- a/MundiPaggService/PostNotification/OnlineDebitTransactionNotification.php
+++ b/MundiPaggService/PostNotification/OnlineDebitTransactionNotification.php
@@ -16,4 +16,3 @@ class OnlineDebitTransactionNotification {
 	/*@var [string] Online Debit Transaction Status */
 	public $OnlineDebitTransactionStatus;
 }
-?>

--- a/MundiPaggService/PostNotification/StatusNotification.php
+++ b/MundiPaggService/PostNotification/StatusNotification.php
@@ -165,4 +165,3 @@ final class StatusNotification {
 		return $find === "" || substr($str, -strlen($find)) === $find;
 	}
 }
-?>

--- a/MundiPaggService/PostNotification/StatusNotificationPost.php
+++ b/MundiPaggService/PostNotification/StatusNotificationPost.php
@@ -63,4 +63,3 @@ function ParseXmlToStatusNotification($xml) {
 	
 	return $statusNotification;
 }
-?>

--- a/MundiPaggService/PostNotification/TestScript.php
+++ b/MundiPaggService/PostNotification/TestScript.php
@@ -161,4 +161,3 @@ function GetNoTransactionsXml() {
 </StatusNotification>') );
 }
 
-?>

--- a/MundiPaggService/ServiceClient/IMundiPaggDebitServiceClient.php
+++ b/MundiPaggService/ServiceClient/IMundiPaggDebitServiceClient.php
@@ -22,4 +22,3 @@ interface IMundiPaggDebitServiceClient {
 	*/
 	public function QueryOrder($orderIdentification, $merchantKey = NULL);
 }
-?>

--- a/MundiPaggService/ServiceClient/IMundiPaggReportServiceClient.php
+++ b/MundiPaggService/ServiceClient/IMundiPaggReportServiceClient.php
@@ -28,4 +28,3 @@ interface IMundiPaggReportServiceClient {
 	*/
 	public function GetBytes(DateTime $fileDate, $merchantKey = NULL);
 }
-?>

--- a/MundiPaggService/ServiceClient/IMundiPaggServiceClient.php
+++ b/MundiPaggService/ServiceClient/IMundiPaggServiceClient.php
@@ -44,4 +44,3 @@ interface IMundiPaggServiceClient {
 	*/
 	public function GetInstantBuyData(GetInstantBuyDataRequest $getInstantBuyDataRequest);
 }
-?>

--- a/MundiPaggService/ServiceClient/MundiPaggDebitServiceClient.php
+++ b/MundiPaggService/ServiceClient/MundiPaggDebitServiceClient.php
@@ -135,4 +135,3 @@ class MundiPaggDebitServiceClient implements IMundiPaggDebitServiceClient {
 		return $responseArray;
 	}
 }
-?>

--- a/MundiPaggService/ServiceClient/MundiPaggReportServiceClient.php
+++ b/MundiPaggService/ServiceClient/MundiPaggReportServiceClient.php
@@ -101,4 +101,3 @@ class MundiPaggReportServiceClient implements IMundiPaggReportServiceClient {
 		return $httpResponse->ResponseContent;
 	}
 }
-?>

--- a/MundiPaggService/ServiceClient/MundiPaggRestServiceClient.php
+++ b/MundiPaggService/ServiceClient/MundiPaggRestServiceClient.php
@@ -248,4 +248,3 @@ class MundiPaggRestServiceClient {
 		if ($this->isClosed) { throw new Exception("The client is closed!"); }
 	}
 }
-?>

--- a/MundiPaggService/ServiceClient/MundiPaggSoapServiceClient.php
+++ b/MundiPaggService/ServiceClient/MundiPaggSoapServiceClient.php
@@ -288,4 +288,3 @@ class MundiPaggSoapServiceClient implements IMundiPaggServiceClient {
 		return $find === "" || substr($str, -strlen($find)) === $find;
 	}
 }
-?>

--- a/MundiPaggServiceConfiguration.php
+++ b/MundiPaggServiceConfiguration.php
@@ -57,4 +57,3 @@
 
 	define( "MP_STATUS_NOTIF_POST" , "xmlStatusNotification" );
 	
-?>

--- a/TestScript-PostNotification.php
+++ b/TestScript-PostNotification.php
@@ -162,4 +162,3 @@ function GetNoTransactionsXml() {
 </StatusNotification>') );
 }
 
-?>

--- a/TestScript.php
+++ b/TestScript.php
@@ -207,4 +207,3 @@ function CreateGetInstantBuyData($buyerKey) {
 
 	return $instantBuyRequest;
 }
-?>

--- a/UnitTests/AuxFuncions.php
+++ b/UnitTests/AuxFuncions.php
@@ -330,4 +330,3 @@ function CreateBoletoTransactionDataCollection() {
 	return $boletoTransactionDataCollection;
 
 }
-?>

--- a/UnitTests/ConverterTest.php
+++ b/UnitTests/ConverterTest.php
@@ -401,4 +401,3 @@ class ConverterTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 }
-?>

--- a/UnitTests/MundiPaggServiceClientTest.php
+++ b/UnitTests/MundiPaggServiceClientTest.php
@@ -21,4 +21,3 @@ class MundiPaggServiceClientTest extends PHPUnit_Framework_TestCase {
 
 
 }	
-?>

--- a/UnitTests/Variables.php
+++ b/UnitTests/Variables.php
@@ -14,4 +14,3 @@
 	//const WSDL = 'https://transaction.mundipaggone.com/MundiPaggService.svc?wsdl';
 	$PRODUCTION_WSDL = $LOCAL_WSDL . "wsdl.xml";
 	$SANDBOX_WSDL = $LOCAL_WSDL . "wsdl.xml";
-?>


### PR DESCRIPTION
[PHP manual says](http://php.net/manual/en/language.basic-syntax.phptags.php):

> If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file. This prevents accidental whitespace or new lines being added after the PHP closing tag, which may cause unwanted effects because PHP will start output buffering when there is no intention from the programmer to send any output at that point in the script.